### PR TITLE
No longer disable audio session post recording

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-audio",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "React Native extension for recording audio",
   "main": "index.js",
   "author": "Joshua Sierles <joshua@diluvia.net> (https://github.com/jsierles)",


### PR DESCRIPTION
Since sound & audio recording share the same audio session singleton, we no longer modify the session's active state post-recording to prevent possible undefined behavior.  (This may be related to game freezes).