### PR TITLE
Fix for small issue when audio recording is interrupted

### DIFF
--- a/ios/AudioRecorderManager.swift
+++ b/ios/AudioRecorderManager.swift
@@ -252,14 +252,18 @@ class AudioRecorderManager: NSObject, RCTBridgeModule, AVAudioRecorderDelegate {
     }
     
     func audioSessionInterrupted(_ notification: Notification) {
-        let reason = (notification.userInfo![AVAudioSessionInterruptionTypeKey] as AnyObject).uintValue
-        if reason == AVAudioSessionInterruptionType.began.rawValue {
-            try! self._setSessionActive(active: true)
-        } else {
-            if self.recording {
-                self._audioRecorder?.stop()
+        do {
+            let reason = (notification.userInfo![AVAudioSessionInterruptionTypeKey] as AnyObject).uintValue
+            if reason == AVAudioSessionInterruptionType.began.rawValue {
+                if self.recording {
+                    self._audioRecorder?.stop()
+                }
+                try self._setSessionActive(active: false)
+            } else {
+                try self._setSessionActive(active: false)
             }
-            try! self._setSessionActive(active: false)
+        } catch let error {
+            print("[ERROR] Audio recording interrupted error: \(String(describing: error))")
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-audio",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "React Native extension for recording audio",
   "main": "index.js",
   "author": "Joshua Sierles <joshua@diluvia.net> (https://github.com/jsierles)",


### PR DESCRIPTION
Removing the swift crash operator `!` and just let the error fail silently 