### PR TITLE
Two Android Crashes Fixed

### DIFF
--- a/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
+++ b/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
@@ -115,7 +115,13 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void checkAuthorizationStatus(Promise promise) {
-    int permissionCheck = ContextCompat.checkSelfPermission(getCurrentActivity(), Manifest.permission.RECORD_AUDIO);
+    Activity currentActivity = getCurrentActivity();
+    if (currentActivity == null) {
+      promise.reject("E_ACTIVITY_DOES_NOT_EXIST", "Activity doesn't exist");
+      return;
+    }
+
+    int permissionCheck = ContextCompat.checkSelfPermission(currentActivity, Manifest.permission.RECORD_AUDIO);
     boolean permissionGranted = permissionCheck == PackageManager.PERMISSION_GRANTED;
     promise.resolve(permissionGranted);
   }
@@ -159,6 +165,8 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
           grantResults[0] == PackageManager.PERMISSION_GRANTED &&
           grantResults[1] == PackageManager.PERMISSION_GRANTED);
     }
+    // no longer need the promise; discard local reference
+    requestPromise = null;
   }
 
   @ReactMethod

--- a/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
+++ b/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
@@ -164,6 +164,11 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
   @ReactMethod
   public void startRecording(String filePath, Promise promise) {
 
+    if (isRecording) {
+      logAndRejectPromise(promise, "INVALID_STATE", "Please call stopRecording before starting recording");
+      return;
+    }
+  
     if (filePath == null) {
       filePath = "/sdcard";
     }
@@ -193,10 +198,6 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
 
     if (recorder == null) {
       logAndRejectPromise(promise, "RECORDING_NOT_PREPARED", "Please call prepareRecordingAtPath before starting recording");
-      return;
-    }
-    if (isRecording) {
-      logAndRejectPromise(promise, "INVALID_STATE", "Please call stopRecording before starting recording");
       return;
     }
     recorder.startRecording();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-audio",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "React Native extension for recording audio",
   "main": "index.js",
   "author": "Joshua Sierles <joshua@diluvia.net> (https://github.com/jsierles)",


### PR DESCRIPTION
* Fix for crash when calling startRecord repeatedly 
* Check authorization status crashes when `getCurrentActivity()` is null. Prevented. 