### PR TITLE
Use atomic boolean to track isRecording toggle flag

### DIFF
--- a/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
+++ b/android/src/main/java/com/rnim/rn/audio/AudioRecorderManager.java
@@ -173,7 +173,7 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
   @ReactMethod
   public void startRecording(String filePath, Promise promise) {
 
-    if (isRecording.get()) {
+    if (isRecording.compareAndSet(false, true) == false) {
       logAndRejectPromise(promise, "INVALID_STATE", "Please call stopRecording before starting recording");
       return;
     }
@@ -206,12 +206,12 @@ class AudioRecorderManager extends ReactContextBaseJavaModule {
     }
 
     if (recorder == null) {
+      isRecording.set(false);
       logAndRejectPromise(promise, "RECORDING_NOT_PREPARED", "Please call prepareRecordingAtPath before starting recording");
       return;
     }
     recorder.startRecording();
     currentFilePath = filePath;
-    isRecording.set(true);
     recordingThread = new Thread(new Runnable() {
       public void run() {
         writeAudioDataToFile();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-audio",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "description": "React Native extension for recording audio",
   "main": "index.js",
   "author": "Joshua Sierles <joshua@diluvia.net> (https://github.com/jsierles)",


### PR DESCRIPTION
@tony-krnl This is an attempt to use java's concurrent AtomicBoolean class to fix the "stop before start" recording crash. Using `volatile` is another way this could be fixed as well. 

Want to get a second pair of eyes on this because it's sensitive stuff